### PR TITLE
Changed from CONFIG+=ordered to depends to support parallel builds with make -j 8

### DIFF
--- a/MyProject.pro
+++ b/MyProject.pro
@@ -1,4 +1,5 @@
 TEMPLATE = subdirs
+CONFIG+=ordered
 SUBDIRS = \
     src \
     app \

--- a/MyProject.pro
+++ b/MyProject.pro
@@ -4,7 +4,8 @@ SUBDIRS = \
     app \
     tests
 
-CONFIG += ordered
+app.depends = src
+tests.depends = src
 
 OTHER_FILES += \
     defaults.pri


### PR DESCRIPTION
According to this blog post, this is the way to make parallel builds work, because the ordered property does not do this properly (src may be finished building after tests start building with make -j 8):

http://blog.rburchell.com/2013/10/every-time-you-configordered-kitten-dies.html
